### PR TITLE
Adds optional keyFile config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ npm install -g homebridge-lgtv2
       "accessory": "LGTv2",
       "name": "TV",
       "mac": "E8:F2:E2:09:C2:56",
-      "ip": "10.0.1.4"
+      "ip": "10.0.1.4",
+      "keyFile": "/var/homebridge/lgtv-"
     }
   ]
 }
 ```
+
+keyFile: Optional parameter in case the default path in the node_modules/lgtv2 is inaccessible due to permissions.
 
 ## Changelogs
 ### Version 1.2.1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ npm install -g homebridge-lgtv2
 }
 ```
 
-keyFile: Optional parameter in case the default path in the node_modules/lgtv2 is inaccessible due to permissions.
+### Fields
+- "accessory": Must always be "LGTv2" (required).
+- "name": Name of your accessory (required).
+- "mac": Mac Address of your LG TV (required).
+- "ip": IP Address of your LG TV (required).
+- "keyFile": Location to store app permission token for your LGTV (optional).  Defaults to the ./node_modules/lgtv2 plug in folder.
 
 ## Changelogs
 ### Version 1.2.1

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function LGTv2(log, config, api) {
   this.ip = config['ip']
   this.name = config['name']
   this.mac = config['mac']
+  this.keyFile = config['keyFile']
   this.powered = false
 
   this.service = new Service.Switch(this.name)
@@ -64,6 +65,7 @@ LGTv2.prototype.setState = function(state, callback) {
       var cb = false
       var lgtv = require('lgtv2')({
         url: 'ws://' + this.ip + ':3000',
+        keyFile: this.keyFile,
         timeout: 4000,
         reconnect: 0
       })


### PR DESCRIPTION
Resolves https://github.com/alessiodionisi/homebridge-lgtv2/issues/3 .

Depending on the user homebridge is being executed with, you may not have permissions to write to the default file location for the LGTV key, required by the LGTV2 dependency.  

This change introduces a new keyFile config option to provide an alternative location that the user has access to read/write to.